### PR TITLE
eslint type object to file

### DIFF
--- a/dist/rules.js
+++ b/dist/rules.js
@@ -19,7 +19,8 @@ var rules = [
         attrib: 'href',
         disallow: ['{{'],
         require: [],
-        msg: 'Angular expression used within href attribute.'
+        msg: 'Angular expression used within href attribute.',
+        severity: 1
     },
     /**
      * `src="{{prop}}"` can cause a request for an incorrect resource. Prefer `ng-src="{{prop}}"`.
@@ -29,7 +30,8 @@ var rules = [
         attrib: 'src',
         disallow: ['{{'],
         require: [],
-        msg: 'Angular expression used within src attribute.'
+        msg: 'Angular expression used within src attribute.',
+        severity: 1
     },
     /**
      * `style="background-image:{{prop}}"` can cause a request for an incorrect resource. Prefer `ng-style="'background-image':'{{prop}}'"`.
@@ -39,7 +41,8 @@ var rules = [
         attrib: 'style',
         disallow: ['{{'],
         require: [],
-        msg: 'Angular expression used within style attribute.'
+        msg: 'Angular expression used within style attribute.',
+        severity: 1
     },
     /**
      * `<input ng-model="prop">` can cause shadowing of inherited properties and confusing UI behavior. Prefer `<input ng-model="prop.foo">`.
@@ -49,7 +52,8 @@ var rules = [
         attrib: 'ng-model',
         disallow: [],
         require: ['.'],
-        msg: 'No `.` in ng-model expression.'
+        msg: 'No `.` in ng-model expression.',
+        severity: 1
     }
 ];
 
@@ -73,6 +77,7 @@ function generateRule(options) {
                             file: file,
                             tagLineNum: tagLineNum,
                             msg: options.msg,
+                            severity: options.severity,
                             ruleName: options.name
                         };
                     }
@@ -92,6 +97,7 @@ function generateRule(options) {
                             file: file,
                             tagLineNum: tagLineNum,
                             msg: options.msg,
+                            severity: options.severity,
                             ruleName: options.name
                         };
                     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-ng-template-validate",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Gulp plugin for validating AngularJS templates for common issues.",
   "author": "Kevin Phillips <kphillips@cars.com>",
   "license": "Apache 2.0",

--- a/src/rules.js
+++ b/src/rules.js
@@ -19,7 +19,8 @@ var rules = [
         attrib: 'href',
         disallow: ['{{'],
         require: [],
-        msg: 'Angular expression used within href attribute.'
+        msg: 'Angular expression used within href attribute.',
+        severity: 1
     },
     /**
      * `src="{{prop}}"` can cause a request for an incorrect resource. Prefer `ng-src="{{prop}}"`.
@@ -29,7 +30,8 @@ var rules = [
         attrib: 'src',
         disallow: ['{{'],
         require: [],
-        msg: 'Angular expression used within src attribute.'
+        msg: 'Angular expression used within src attribute.',
+        severity: 1
     },
     /**
      * `style="background-image:{{prop}}"` can cause a request for an incorrect resource. Prefer `ng-style="'background-image':'{{prop}}'"`.
@@ -39,7 +41,8 @@ var rules = [
         attrib: 'style',
         disallow: ['{{'],
         require: [],
-        msg: 'Angular expression used within style attribute.'
+        msg: 'Angular expression used within style attribute.',
+        severity: 1
     },
     /**
      * `<input ng-model="prop">` can cause shadowing of inherited properties and confusing UI behavior. Prefer `<input ng-model="prop.foo">`.
@@ -49,7 +52,8 @@ var rules = [
         attrib: 'ng-model',
         disallow: [],
         require: ['.'],
-        msg: 'No `.` in ng-model expression.'
+        msg: 'No `.` in ng-model expression.',
+        severity: 1
     }
 ];
 
@@ -73,6 +77,7 @@ function generateRule(options) {
                             file: file,
                             tagLineNum: tagLineNum,
                             msg: options.msg,
+                            severity: options.severity,
                             ruleName: options.name
                         };
                     }
@@ -92,6 +97,7 @@ function generateRule(options) {
                             file: file,
                             tagLineNum: tagLineNum,
                             msg: options.msg,
+                            severity: options.severity,
                             ruleName: options.name
                         };
                     }

--- a/test/index.js
+++ b/test/index.js
@@ -187,10 +187,8 @@ describe('gulp-ng-template-validate', function() {
                     }
                 ];
 
-                it('should log errors', function () {
-                    var currentLogMsg = 0;
-
-                    testCases.forEach(function (testCase) {
+                it('should have an eslint object on file', function() {
+                    testCases.forEach(function(testCase){
                         var fakeFile,
                             fakeFileContents;
 
@@ -202,10 +200,8 @@ describe('gulp-ng-template-validate', function() {
                         });
 
                         stream.write(fakeFile);
-
-                        testCase.logMsgs.forEach(function (msg) {
-                            console.log.getCall(currentLogMsg++).args[0].should.eql(msg);
-                        });
+                        (typeof fakeFile.eslint).should.equal('object');
+                        (fakeFile.eslint.messages instanceof Array).should.equal(true);
                     });
                 });
             });


### PR DESCRIPTION
Instead of logging the error as it it is validated, this adds an eslint object to each file like gulp-eslint. This lets the user use the information in anyway they want. For example, retrieving the committer of each validation message.